### PR TITLE
chore: update repo references from McTalian/ to McTalian-WoW-Addons/

### DIFF
--- a/.github/docs/development-status.md
+++ b/.github/docs/development-status.md
@@ -21,7 +21,7 @@
 - **Next idea**: Load-order test to cover module-level initialization code not wrapped in functions
 
 **Gossip Protocol v2 — Digest-Based Exchange (Feb 27 AM)** ✅
-- **Issue**: [#9 - Overly eager gossip protocol](https://github.com/McTalian/Endeavoring/issues/9)
+- **Issue**: [#9 - Overly eager gossip protocol](https://github.com/McTalian-WoW-Addons/Endeavoring/issues/9)
 - **Problem**: Old gossip sent 3-15+ unsolicited whisper messages per MANIFEST received, causing `AddonMessageThrottle` errors in active guilds
 - **Solution**: Replaced push-based gossip with digest-based handshake protocol
 - **Phase 1** ✅: Switched all senders to short wire keys (`ns.SK`), saving ~30-50 bytes per message

--- a/.github/plans/issue-9.md
+++ b/.github/plans/issue-9.md
@@ -1,6 +1,6 @@
 # Feature Plan: Gossip Protocol v2 — Digest-based Exchange + Short Wire Keys
 
-**Issue**: [#9 - Overly eager gossip protocol](https://github.com/McTalian/Endeavoring/issues/9)
+**Issue**: [#9 - Overly eager gossip protocol](https://github.com/McTalian-WoW-Addons/Endeavoring/issues/9)
 **Created**: February 27, 2026
 
 ## Overview

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -104,7 +104,7 @@ This layered approach ensures workflows have just the right context without over
 - Architecture diagrams (if applicable)
 - Saved plan document at `.github/plans/issue-42.md`
 
-**Note**: Create the GitHub issue first at https://github.com/McTalian/Endeavoring/issues/new/choose
+**Note**: Create the GitHub issue first at https://github.com/McTalian-WoW-Addons/Endeavoring/issues/new/choose
 
 ---
 
@@ -269,7 +269,7 @@ These prompts are designed to work together:
 
 **Issue-Based Development Flow** (Recommended):
 ```
-[Create issue]         → https://github.com/McTalian/Endeavoring/issues/new
+[Create issue]         → https://github.com/McTalian-WoW-Addons/Endeavoring/issues/new
 /plan #42              → Load issue, create implementation plan
                        → Plan saved to .github/plans/issue-42.md
 /implement #42         → Load issue + plan, execute implementation

--- a/.github/prompts/implement.prompt.md
+++ b/.github/prompts/implement.prompt.md
@@ -19,7 +19,7 @@ You are implementing a feature or enhancement based on a GitHub issue. This work
 - If no number provided, ask the user which issue to implement
 
 **Fetch the issue** using GitHub tools:
-1. Fetch issue content: `github-pull-request_issue_fetch(owner: "McTalian", repo: "Endeavoring", issue_number: 123)`
+1. Fetch issue content: `github-pull-request_issue_fetch(owner: "McTalian-WoW-Addons", repo: "Endeavoring", issue_number: 123)`
 2. Extract key information:
    - Issue title and description
    - Labels (complexity, priority indicators)

--- a/.github/prompts/plan.prompt.md
+++ b/.github/prompts/plan.prompt.md
@@ -15,10 +15,10 @@ You are collaborating with the user to plan a feature from a GitHub issue. Your 
 **This workflow requires a GitHub issue number.**
 
 - Extract issue number from formats like: `#123`, `123`, `issue 123`
-- If no issue number provided, ask: "Please provide an issue number to plan (e.g., `/plan #123`). Create an issue first at https://github.com/McTalian/Endeavoring/issues/new/choose"
+- If no issue number provided, ask: "Please provide an issue number to plan (e.g., `/plan #123`). Create an issue first at https://github.com/McTalian-WoW-Addons/Endeavoring/issues/new/choose"
 
 **Fetch the issue**:
-1. Call: `github-pull-request_issue_fetch(owner: "McTalian", repo: "Endeavoring", issue_number: 123)`
+1. Call: `github-pull-request_issue_fetch(owner: "McTalian-WoW-Addons", repo: "Endeavoring", issue_number: 123)`
 2. Extract key information:
    - Issue title and description
    - Labels (complexity, priority indicators)
@@ -295,7 +295,7 @@ Midnight is new - APIs might change:
 → Loads issue #42, creates detailed implementation plan, saves to `.github/plans/issue-42.md`
 
 **Typical workflow**:
-1. Create issue: https://github.com/McTalian/Endeavoring/issues/new/choose
+1. Create issue: https://github.com/McTalian-WoW-Addons/Endeavoring/issues/new/choose
 2. Run `/plan #123` to create technical design
 3. Plan is saved for `/implement #123` to reference
 4. Update development-status.md with planned work

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- IMPORTANT: Please review the
-[PR title rules](https://github.com/McTalian/Endeavoring/blob/main/docs/pr-title-rules.md)
+[PR title rules](https://github.com/McTalian-WoW-Addons/Endeavoring/blob/main/docs/pr-title-rules.md)
 so the PR checks will pass. -->
 
 **Description**:

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Package and distribute
         env:
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-        uses: McTalian/wow-build-tools@v1-beta
+        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
         with:
           args: -t ./Endeavoring -r ./.release
 
@@ -43,17 +43,17 @@ jobs:
         with:
           webhook-url: ${{ env.DISCORD_WEBHOOK_URL }}
           username: Endeavoring Releases
-          avatar-url: https://raw.githubusercontent.com/McTalian/Endeavoring/refs/heads/main/Endeavoring/Icons/endeavoring.png
+          avatar-url: https://raw.githubusercontent.com/McTalian-WoW-Addons/Endeavoring/refs/heads/main/Endeavoring/Icons/endeavoring.png
           embed-title: "New Endeavoring Release: ${{ github.event.release.tag_name || ':tada:' }}"
           embed-description: |
             ${{ github.event.release.body || '' }}
 
-            Be the first to download via :octopus: [GitHub](${{ github.event.release.html_url || 'https://github.com/McTalian/Endeavoring/releases' }}) :coin:
+            Be the first to download via :octopus: [GitHub](${{ github.event.release.html_url || 'https://github.com/McTalian-WoW-Addons/Endeavoring/releases' }}) :coin:
 
             Once approved it will also be available via:
             * :fire: [CurseForge](https://www.curseforge.com/wow/addons/endeavoring)
             * :wireless: [WoWInterface](https://www.wowinterface.com/downloads/info27047-Endeavoring.html)
             * :knot: [Wago](https://addons.wago.io/addons/endeavoring)
 
-            > _**Running into issues?** Let me know on [GitHub](https://github.com/McTalian/Endeavoring/issues) or join the [Discord](https://discord.gg/czRYVWhe33) for the fastest updates and support!_
+            > _**Running into issues?** Let me know on [GitHub](https://github.com/McTalian-WoW-Addons/Endeavoring/issues) or join the [Discord](https://discord.gg/czRYVWhe33) for the fastest updates and support!_
           embed-color: 15105570

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -107,7 +107,7 @@ jobs:
           fi
 
       - name: Package
-        uses: McTalian/wow-build-tools@v1-beta
+        uses: McTalian-WoW-Addons/wow-build-tools@v1-beta
         with:
           args: -d -t ./Endeavoring -r ./.release --skipChangelog -n {package-name}-pr${{github.event.number}}-{nolib}{classic}
 

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update TOC Interface version
-        uses: Mctalian/wow-build-tools/toc/update@v1-beta
+        uses: McTalian-WoW-Addons/wow-build-tools/toc/update@v1-beta
         with:
           args: -a ${{ env.ADDON }} -b -p
 

--- a/Endeavoring/Features/Settings.lua
+++ b/Endeavoring/Features/Settings.lua
@@ -278,7 +278,7 @@ StaticPopupDialogs["ENDEAVORING_ABOUT"] = {
 	       "Addon icon by Delapouite (delapouite.com)\n" ..
 	       "Licensed under CC BY 3.0\n" ..
 	       "Modified and downloaded via game-icons.net\n\n" ..
-	       "|cFF888888GitHub:|r github.com/McTalian/Endeavoring\n" ..
+	       "|cFF888888GitHub:|r github.com/McTalian-WoW-Addons/Endeavoring\n" ..
 	       "|cFF888888Discord:|r discord.gg/czRYVWhe33",
 	button1 = "Close",
 	timeout = 0,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install directly through your favorite addon manager:
 
 ### Manual Install
 
-1. Download the latest release from [GitHub Releases](https://github.com/McTalian/Endeavoring/releases), [CurseForge](https://www.curseforge.com/wow/addons/endeavoring), [WoWInterface](https://www.wowinterface.com/downloads/info27047-Endeavoring.html), or [Wago](https://addons.wago.io/addons/endeavoring)
+1. Download the latest release from [GitHub Releases](https://github.com/McTalian-WoW-Addons/Endeavoring/releases), [CurseForge](https://www.curseforge.com/wow/addons/endeavoring), [WoWInterface](https://www.wowinterface.com/downloads/info27047-Endeavoring.html), or [Wago](https://addons.wago.io/addons/endeavoring)
 2. Extract to `World of Warcraft/_retail_/Interface/AddOns/`
 3. Make sure the folder is named `Endeavoring`
 4. Restart WoW or `/reload`
@@ -61,7 +61,7 @@ Install directly through your favorite addon manager:
 
 ## Support & Bugs
 
-- **GitHub:** [McTalian/Endeavoring](https://github.com/McTalian/Endeavoring)
+- **GitHub:** [McTalian-WoW-Addons/Endeavoring](https://github.com/McTalian-WoW-Addons/Endeavoring)
 - **Discord:** [Join here](https://discord.gg/czRYVWhe33)
 
 Found a bug? Open an issue on GitHub or ping me on Discord. Include any error messages from BugSnag/BugGrabber or `/console scriptErrors 1` if you can.


### PR DESCRIPTION
**Description**:

Update all hardcoded GitHub references to reflect the new org:
- Workflow action references (wow-build-tools)
- Discord embed URLs and message body links
- README links
- In-game Settings.lua GitHub link
- Prompt files and plan documents
- PR template link

**Related Issue**:

N/A

**Screenshots, Videos, or GIFs**:

N/A