### PR TITLE
fix: showing endeavoring locks game up if no endeavor has been chosen

### DIFF
--- a/Endeavoring/Cache/ActivityLogCache.lua
+++ b/Endeavoring/Cache/ActivityLogCache.lua
@@ -31,6 +31,12 @@ INVALIDATION:
 
 local DebugPrint = ns.DebugPrint
 
+-- Guard to prevent re-entrant stale cache refresh requests.
+-- When stale data triggers RequestInitiativeInfo, the event response can
+-- synchronously fire NEIGHBORHOOD_INITIATIVE_UPDATED → RequestActivityLog →
+-- INITIATIVE_ACTIVITY_LOG_UPDATED → Get() again, creating an infinite cycle.
+local staleRefreshPending = false
+
 --- Get activity log info with caching support
 --- Returns cached data immediately if available, schedules background update
 --- @return table|nil activityLogInfo The activity log info (cached or live)
@@ -50,14 +56,19 @@ function ActivityLogCache.Get()
 	if liveData and liveData.isLoaded and #liveData.taskActivity > 0 then
 		-- Live data is loaded, update cache and return it
 		ns.DB.SetActivityLogCache(neighborhoodGUID, liveData)
+		staleRefreshPending = false
 		return liveData
 	end
 	
 	-- Live data not loaded yet, try to return cached data
 	local cachedData, isStale = ns.DB.GetActivityLogCache(neighborhoodGUID)
 	if cachedData then
-		if isStale then
-			ns.API.RequestInitiativeInfo() -- Request update so we'll get updated whenever Blizzard decides to send it
+		if isStale and not staleRefreshPending then
+			-- Defer the request to next frame to break any synchronous event cycle
+			staleRefreshPending = true
+			C_Timer.After(0, function()
+				ns.API.RequestInitiativeInfo()
+			end)
 		end
 		
 		return cachedData

--- a/Endeavoring/Features/Activity.lua
+++ b/Endeavoring/Features/Activity.lua
@@ -687,11 +687,13 @@ function Activity.CreateTab(parent)
 	emptyText:Hide()
 	content.emptyText = emptyText
 
-	-- Register for activity log updates
+	-- Register for activity log updates (only refresh when visible)
 	local eventFrame = CreateFrame("Frame")
 	eventFrame:RegisterEvent("INITIATIVE_ACTIVITY_LOG_UPDATED")
 	eventFrame:SetScript("OnEvent", function()
-		Activity.Refresh()
+		if content:IsVisible() then
+			Activity.Refresh()
+		end
 	end)
 	content.eventFrame = eventFrame
 

--- a/Endeavoring/Features/Leaderboard.lua
+++ b/Endeavoring/Features/Leaderboard.lua
@@ -595,10 +595,10 @@ function Leaderboard.CreateTab(parent)
 	emptyText:SetText(constants.NO_LEADERBOARD_DATA)
 	emptyText:Hide()
 
-	-- Register event handler for activity log updates
+	-- Register event handler for activity log updates (only refresh when visible)
 	content:RegisterEvent("INITIATIVE_ACTIVITY_LOG_UPDATED")
 	content:SetScript("OnEvent", function(self, event)
-		if event == "INITIATIVE_ACTIVITY_LOG_UPDATED" then
+		if event == "INITIATIVE_ACTIVITY_LOG_UPDATED" and self:IsVisible() then
 			UpdateLeaderboardDisplay()
 		end
 	end)

--- a/Endeavoring_spec/Cache/ActivityLogCache_spec.lua
+++ b/Endeavoring_spec/Cache/ActivityLogCache_spec.lua
@@ -81,9 +81,64 @@ describe("ActivityLogCache", function()
 			local requestCalled = false
 			ns.API.RequestInitiativeInfo = function() requestCalled = true end
 
+			-- Make C_Timer.After execute callback immediately for testing
+			_G.C_Timer.After = function(_, callback) callback() end
+
 			local result = Cache.Get()
 			assert.are.equal(cachedData, result)
 			assert.is_true(requestCalled) -- Should trigger background update
+		end)
+
+		it("should not re-request when stale refresh is already pending", function()
+			local ns, Cache = SetupActivityLogCache()
+
+			ns.API.GetActivityLogInfo = function() return nil end
+			ns.API.GetActiveNeighborhoodGUID = function() return "GUID-1" end
+
+			local cachedData = { isLoaded = true, taskActivity = { { taskID = 1 } } }
+			ns.DB.GetActivityLogCache = function() return cachedData, true end
+
+			local requestCount = 0
+			ns.API.RequestInitiativeInfo = function() requestCount = requestCount + 1 end
+
+			-- Don't execute callback so the guard stays pending
+			_G.C_Timer.After = function(_, _) end
+
+			Cache.Get() -- First call sets staleRefreshPending
+			Cache.Get() -- Second call should skip request
+
+			assert.are.equal(0, requestCount) -- Deferred, not called yet
+		end)
+
+		it("should allow re-request after live data clears the guard", function()
+			local ns, Cache = SetupActivityLogCache()
+
+			ns.API.GetActiveNeighborhoodGUID = function() return "GUID-1" end
+
+			local cachedData = { isLoaded = true, taskActivity = { { taskID = 1 } } }
+			ns.DB.GetActivityLogCache = function() return cachedData, true end
+
+			local requestCount = 0
+			ns.API.RequestInitiativeInfo = function() requestCount = requestCount + 1 end
+
+			-- Don't execute callback so the guard stays pending
+			_G.C_Timer.After = function(_, _) end
+			ns.API.GetActivityLogInfo = function() return nil end
+
+			Cache.Get() -- Sets staleRefreshPending
+
+			-- Now simulate live data arriving (clears the guard)
+			local liveData = { isLoaded = true, taskActivity = { { taskID = 2 } } }
+			ns.API.GetActivityLogInfo = function() return liveData end
+			ns.DB.SetActivityLogCache = function() end
+			Cache.Get() -- Should clear guard via live data path
+
+			-- Back to stale state
+			ns.API.GetActivityLogInfo = function() return nil end
+			_G.C_Timer.After = function(_, callback) callback() end
+			Cache.Get() -- Should request again since guard was cleared
+
+			assert.are.equal(1, requestCount)
 		end)
 
 		it("should return live data when no neighborhood GUID available", function()


### PR DESCRIPTION
**Description**:

If an endeavor hasn't been chosen and you try to open endeavoring, the game will lock up.

**Related Issue**:

N/A, found today when endeavors reset.

**Screenshots, Videos, or GIFs**:

N/A