### PR TITLE
ci: add job-level permissions to caller workflows

### DIFF
--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -7,4 +7,8 @@ permissions: {}
 
 jobs:
   stale:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/cleanup-stale-issues.yml@v1-beta

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -9,6 +9,8 @@ permissions: {}
 
 jobs:
   package-and-release:
+    permissions:
+      contents: write
     uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1-beta
     with:
       addon-name: Endeavoring

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -9,6 +9,9 @@ permissions: {}
 
 jobs:
   toc-update:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1-beta
     with:
       addon-name: Endeavoring


### PR DESCRIPTION
Adds the union of sub-job permissions from each reusable workflow to the caller job level. The top-level `permissions: {}` caps GITHUB_TOKEN to `none`, so reusable workflows that declare their own permissions (like `toc-updater`) fail with `startup_failure`.

**Fixed callers:**
- `cleanup-stale-issues.yml` — `contents: read, issues: write, pull-requests: write`
- `package-and-distribute.yml` — `contents: write`
- `toc-updater.yml` — `contents: write, pull-requests: write`

Note: `main.yml` and `pr-checks.yml` already had job-level permissions from Session 4.