### PR TITLE
feat: add endeavor chest indicator

### DIFF
--- a/Endeavoring/Bootstrap.lua
+++ b/Endeavoring/Bootstrap.lua
@@ -61,6 +61,12 @@ ns.Constants = ns.Constants or {
 	PREFIX_INFO = "|cff00ff00" .. addonName .. ":|r",
 	PREFIX_ERROR = "|cffff0000" .. addonName .. ":|r",
 	PREFIX_WARN = "|cffff8800" .. addonName .. ":|r",
+	-- Spell cast by the player when opening the Endeavor Coffer (chest).
+	-- Sourced from Midnight (12.0.1) by inspecting etrace
+	-- UNIT_SPELLCAST_SUCCEEDED for the player when interacting with the Endeavor Coffer.
+	-- To re-verify after patches: enable /etrace, open an Endeavor Coffer,
+	-- and confirm the spellID in the UNIT_SPELLCAST_SUCCEEDED event for your character still matches this value.
+	ENDEAVOR_COFFER_SPELL_ID = 1283568,
 }
 
 --- Message types for sync protocol (CBOR + compression)

--- a/Endeavoring/Core.lua
+++ b/Endeavoring/Core.lua
@@ -148,6 +148,7 @@ eventFrame:RegisterEvent("INITIATIVE_COMPLETED")
 eventFrame:RegisterEvent("INITIATIVE_TASK_COMPLETED")
 eventFrame:RegisterEvent("INITIATIVE_ACTIVITY_LOG_UPDATED")
 eventFrame:RegisterEvent("GUILD_ROSTER_UPDATE")
+eventFrame:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED")
 eventFrame:SetScript("OnEvent", function(_, event, ...)
 	if event == "PLAYER_ENTERING_WORLD" then
 		local isLogin, isReload = ...
@@ -211,6 +212,17 @@ eventFrame:SetScript("OnEvent", function(_, event, ...)
 	if event == "GUILD_ROSTER_UPDATE" then
 		-- Debounced broadcast on guild roster changes (with random delay)
 		ns.Coordinator.OnGuildRosterUpdate()
+	end
+
+	if event == "UNIT_SPELLCAST_SUCCEEDED" then
+		local unit, _, spellID = ...
+		if unit == "player" and spellID == ns.Constants.ENDEAVOR_COFFER_SPELL_ID then
+			-- Player just opened the Endeavor Coffer — auto-mark as claimed
+			local ok, err = pcall(ns.Header.AutoClaimChest)
+			if not ok then
+				DebugPrint("AutoClaimChest failed: " .. tostring(err))
+			end
+		end
 	end
 end)
 

--- a/Endeavoring/Data/Database.lua
+++ b/Endeavoring/Data/Database.lua
@@ -36,6 +36,7 @@ local DEFAULT_DB = {
 		profiles = {},
 		activityLogCache = {},  -- Keyed by neighborhoodGUID
 		gossipTracking = {},  -- Content-aware gossip tracking: [targetBTag][profileBTag] = {au, cu, cc}
+		claimedChests = {},  -- Keyed by "initiativeID:cycleID", true when player has claimed that cycle's chest
 		verboseDebug = false,
 		settings = nil,  -- User preferences
 		lastSelectedTab = nil,  -- Remember last tab (1=Tasks, 2=Leaderboard, 3=Activity)
@@ -75,7 +76,36 @@ function DB.Init()
 		EndeavoringDB.global.gossipTracking = {}
 	end
 
+	if not EndeavoringDB.global.claimedChests then
+		EndeavoringDB.global.claimedChests = {}
+	end
+
 	-- myProfile will be initialized on first character login
+end
+
+--- Build the SavedVariables key for a chest claim record
+--- @param initiativeID number
+--- @param cycleID number
+--- @return string
+local function makeChestKey(initiativeID, cycleID)
+	return string.format("%d:%d", initiativeID, cycleID)
+end
+
+--- Mark the chest for the given initiative cycle as claimed by the player
+--- @param initiativeID number The initiative ID
+--- @param cycleID number The current cycle ID
+function DB.SetChestClaimed(initiativeID, cycleID)
+	if not initiativeID or not cycleID then return end
+	EndeavoringDB.global.claimedChests[makeChestKey(initiativeID, cycleID)] = true
+end
+
+--- Check whether the chest for the given initiative cycle has been claimed
+--- @param initiativeID number The initiative ID
+--- @param cycleID number The current cycle ID
+--- @return boolean isClaimed true if the chest has been marked as claimed
+function DB.IsChestClaimed(initiativeID, cycleID)
+	if not initiativeID or not cycleID then return false end
+	return EndeavoringDB.global.claimedChests[makeChestKey(initiativeID, cycleID)] == true
 end
 
 --- Register the current character to the player's BattleTag

--- a/Endeavoring/Features/Header.lua
+++ b/Endeavoring/Features/Header.lua
@@ -81,7 +81,8 @@ function Header.Create(parent)
 
 	-- Chest ready indicator (experimental feature)
 	-- Shows when endeavor is complete and chest hasn't been looted
-	local chestIndicator = CreateFrame("Frame", nil, header)
+	-- Use Button instead of Frame so we can handle right-click to dismiss
+	local chestIndicator = CreateFrame("Button", nil, header)
 	header.chestIndicator = chestIndicator
 	chestIndicator:SetSize(24, 24)
 	chestIndicator:SetPoint("LEFT", header.infoIcon, "RIGHT", 0, 0)
@@ -104,17 +105,23 @@ function Header.Create(parent)
 	
 	chestIndicator.animGroup = animGroup
 	
-	-- Tooltip
+	-- Tooltip and click-to-dismiss
 	chestIndicator:EnableMouse(true)
+	chestIndicator:RegisterForClicks("RightButtonUp")
 	chestIndicator:SetScript("OnEnter", function(self)
 		GameTooltip:SetOwner(self, "ANCHOR_BOTTOM")
 		GameTooltip_SetTitle(GameTooltip, "Endeavor Chest Ready!")
 		GameTooltip_AddNormalLine(GameTooltip, "Visit the chest next to the neighborhood bulletin board to claim your reward.")
 		GameTooltip_AddBlankLineToTooltip(GameTooltip)
-		GameTooltip_AddColoredLine(GameTooltip, "This is an experimental feature and may not work as expected.", YELLOW_FONT_COLOR)
+		GameTooltip_AddNormalLine(GameTooltip, "Will dismiss automatically when you open the chest.")
+		GameTooltip_AddColoredLine(GameTooltip, "Right-click to dismiss manually.", GRAY_FONT_COLOR)
 		GameTooltip:Show()
 	end)
 	chestIndicator:SetScript("OnLeave", GameTooltip_Hide)
+	chestIndicator:SetScript("OnClick", function()
+		-- Filtered by RegisterForClicks to only respond to right-clicks
+		Header.MarkChestClaimed(header)
+	end)
 	
 	chestIndicator:Hide() -- Hidden until chest is ready
 	
@@ -145,7 +152,7 @@ function Header.Refresh()
 		for _, milestone in pairs(header.milestones) do
 			milestone:Hide()
 		end
-		Header.UpdateChestIndicator(mainFrame, nil)
+		Header.UpdateChestIndicator(header, nil)
 		return
 	end
 
@@ -184,7 +191,7 @@ function Header.Refresh()
 		end
 		
 		-- Update chest indicator (experimental)
-		Header.UpdateChestIndicator(mainFrame, initiativeInfo)
+		Header.UpdateChestIndicator(header, initiativeInfo)
 	else
 		header.title:SetText(constants.NO_TASK_DATA)
 		header.timeRemaining:SetText(constants.TIME_REMAINING_FALLBACK)
@@ -195,7 +202,7 @@ function Header.Refresh()
 		for _, milestone in pairs(header.milestones) do
 			milestone:Hide()
 		end
-		Header.UpdateChestIndicator(mainFrame, nil)
+		Header.UpdateChestIndicator(header, nil)
 	end
 end
 
@@ -312,14 +319,14 @@ end
 
 --- Update chest ready indicator (experimental feature)
 --- Shows a glowing chest icon when the final milestone is complete but the chest hasn't been looted
---- @param mainFrame table The main Endeavoring frame
+--- @param header table The header frame (as returned by Header.Create)
 --- @param initiativeInfo table|nil Initiative info from API, or nil if no active endeavor
-function Header.UpdateChestIndicator(mainFrame, initiativeInfo)
-	if not mainFrame or not mainFrame.header or not mainFrame.header.chestIndicator then
+function Header.UpdateChestIndicator(header, initiativeInfo)
+	if not header or not header.chestIndicator then
 		return
 	end
 	
-	local chestIndicator = mainFrame.header.chestIndicator
+	local chestIndicator = header.chestIndicator
 	
 	-- Early exit if no active initiative
 	if not initiativeInfo or not initiativeInfo.milestones or #initiativeInfo.milestones == 0 then
@@ -346,26 +353,37 @@ function Header.UpdateChestIndicator(mainFrame, initiativeInfo)
 		return
 	end
 	
-	-- Check if chest has been looted using ReadyForTurnIn
-	local chestQuestID = finalMilestone.rewards[1].rewardQuestID
-	if not chestQuestID or chestQuestID == 0 then
-		chestIndicator:Hide()
-		chestIndicator.animGroup:Stop()
-		return
-	end
-	
-	-- Safe call to ReadyForTurnIn (returns nil if quest doesn't exist or n/a)
-	local isReadyForTurnIn = nil
-	if C_QuestLog and C_QuestLog.ReadyForTurnIn then
-		isReadyForTurnIn = C_QuestLog.ReadyForTurnIn(chestQuestID)
-	end
+	-- WoW provides no reliable client-side API to detect chest loot for this
+	-- reward type. We track claimed state ourselves in SavedVariables, keyed
+	-- by (initiativeID, currentCycleID) so it resets automatically each cycle.
+	local isClaimed = ns.DB.IsChestClaimed(initiativeInfo.initiativeID, initiativeInfo.currentCycleID)
 
-	-- Show indicator if chest is ready to loot
-	if isReadyForTurnIn == true then
+	if not isClaimed then
 		chestIndicator:Show()
 		chestIndicator.animGroup:Play()
 	else
 		chestIndicator:Hide()
 		chestIndicator.animGroup:Stop()
+	end
+end
+
+--- Mark the current initiative cycle's chest as claimed and hide the indicator
+--- @param header table The header frame (as returned by Header.Create)
+function Header.MarkChestClaimed(header)
+	local initiativeInfo = ns.API.GetInitiativeInfo()
+	if not initiativeInfo then return end
+	ns.DB.SetChestClaimed(initiativeInfo.initiativeID, initiativeInfo.currentCycleID)
+	Header.UpdateChestIndicator(header, initiativeInfo)
+end
+
+--- Automatically claim the chest when the Endeavor Coffer spell succeeds.
+--- Called from the UNIT_SPELLCAST_SUCCEEDED event handler; resolves the frame itself.
+function Header.AutoClaimChest()
+	local initiativeInfo = ns.API.GetInitiativeInfo()
+	if not initiativeInfo then return end
+	ns.DB.SetChestClaimed(initiativeInfo.initiativeID, initiativeInfo.currentCycleID)
+	local mainFrame = ns.ui and ns.ui.mainFrame
+	if mainFrame and mainFrame.header then
+		Header.UpdateChestIndicator(mainFrame.header, initiativeInfo)
 	end
 end


### PR DESCRIPTION
**Description**:

Add a chest indicator to the header to help remind players to claim their chests.

**Related Issue**:

Fixes #4

**Screenshots, Videos, or GIFs**:

N/A
